### PR TITLE
Add Weights and Baises Integration

### DIFF
--- a/config/sample_ddpm_128.json
+++ b/config/sample_ddpm_128.json
@@ -90,5 +90,8 @@
             "update_ema_every": 1,
             "ema_decay": 0.9999
         }
+    },
+    "wandb": {
+        "project": "generation_ffhq_ddpm"
     }
 }

--- a/config/sample_sr3_128.json
+++ b/config/sample_sr3_128.json
@@ -89,5 +89,8 @@
             "update_ema_every": 1,
             "ema_decay": 0.9999
         }
+    },
+    "wandb": {
+        "project": "generation_ffhq_sr3"
     }
 }

--- a/config/sr_ddpm_16_128.json
+++ b/config/sr_ddpm_16_128.json
@@ -90,5 +90,8 @@
             "update_ema_every": 1,
             "ema_decay": 0.9999
         }
+    },
+    "wandb": {
+        "project": "sr_ffhq"
     }
 }

--- a/config/sr_sr3_16_128.json
+++ b/config/sr_sr3_16_128.json
@@ -17,7 +17,7 @@
             "name": "FFHQ",
             "mode": "HR", // whether need LR img
             "dataroot": "dataset/ffhq_16_128",
-            "datatype": "img", //lmdb or img, path of img files
+            "datatype": "lmdb", //lmdb or img, path of img files
             "l_resolution": 16, // low resolution need to super_resolution
             "r_resolution": 128, // high resolution
             "batch_size": 4,
@@ -28,8 +28,8 @@
         "val": {
             "name": "CelebaHQ",
             "mode": "LRHR",
-            "dataroot": "dataset/ffhq_16_128",
-            "datatype": "img", //lmdb or img, path of img files
+            "dataroot": "dataset/celebahq_16_128",
+            "datatype": "lmdb", //lmdb or img, path of img files
             "l_resolution": 16,
             "r_resolution": 128,
             "data_len": 50 // data length in validation 

--- a/config/sr_sr3_16_128.json
+++ b/config/sr_sr3_16_128.json
@@ -17,7 +17,7 @@
             "name": "FFHQ",
             "mode": "HR", // whether need LR img
             "dataroot": "dataset/ffhq_16_128",
-            "datatype": "lmdb", //lmdb or img, path of img files
+            "datatype": "img", //lmdb or img, path of img files
             "l_resolution": 16, // low resolution need to super_resolution
             "r_resolution": 128, // high resolution
             "batch_size": 4,
@@ -28,8 +28,8 @@
         "val": {
             "name": "CelebaHQ",
             "mode": "LRHR",
-            "dataroot": "dataset/celebahq_16_128",
-            "datatype": "lmdb", //lmdb or img, path of img files
+            "dataroot": "dataset/ffhq_16_128",
+            "datatype": "img", //lmdb or img, path of img files
             "l_resolution": 16,
             "r_resolution": 128,
             "data_len": 50 // data length in validation 
@@ -89,5 +89,8 @@
             "update_ema_every": 1,
             "ema_decay": 0.9999
         }
+    },
+    "wandb": {
+        "project": "sr_ffhq"
     }
 }

--- a/config/sr_sr3_64_512.json
+++ b/config/sr_sr3_64_512.json
@@ -92,5 +92,8 @@
             "update_ema_every": 1,
             "ema_decay": 0.9999
         }
+    },
+    "wandb": {
+        "project": "distributed_high_sr_ffhq"
     }
 }

--- a/core/logger.py
+++ b/core/logger.py
@@ -22,6 +22,9 @@ def parse(args):
     phase = args.phase
     opt_path = args.config
     gpu_ids = args.gpu_ids
+    enable_wandb = args.enable_wandb
+    log_wandb_ckpt = args.log_wandb_ckpt
+    log_eval = args.log_eval
     # remove comments starting with '//'
     json_str = ''
     with open(opt_path, 'r') as f:
@@ -71,6 +74,11 @@ def parse(args):
     # validation in train phase
     if phase == 'train':
         opt['datasets']['val']['data_len'] = 3
+
+    # W&B Logging
+    opt['enable_wandb'] = enable_wandb
+    opt['log_wandb_ckpt'] = log_wandb_ckpt
+    opt['log_eval'] = log_eval
 
     return opt
 

--- a/core/logger.py
+++ b/core/logger.py
@@ -23,8 +23,6 @@ def parse(args):
     opt_path = args.config
     gpu_ids = args.gpu_ids
     enable_wandb = args.enable_wandb
-    log_wandb_ckpt = args.log_wandb_ckpt
-    log_eval = args.log_eval
     # remove comments starting with '//'
     json_str = ''
     with open(opt_path, 'r') as f:
@@ -76,10 +74,23 @@ def parse(args):
         opt['datasets']['val']['data_len'] = 3
 
     # W&B Logging
+    try:
+        log_wandb_ckpt = args.log_wandb_ckpt
+        opt['log_wandb_ckpt'] = log_wandb_ckpt
+    except:
+        pass
+    try:
+        log_eval = args.log_eval
+        opt['log_eval'] = log_eval
+    except:
+        pass
+    try:
+        log_infer = args.log_infer
+        opt['log_infer'] = log_infer
+    except:
+        pass
     opt['enable_wandb'] = enable_wandb
-    opt['log_wandb_ckpt'] = log_wandb_ckpt
-    opt['log_eval'] = log_eval
-
+    
     return opt
 
 

--- a/core/wandb_logger.py
+++ b/core/wandb_logger.py
@@ -1,0 +1,88 @@
+import os
+
+class WandbLogger:
+    """
+    Log using `Weights and Biases`.
+    """
+    def __init__(self, opt):
+        try:
+            import wandb
+        except ImportError:
+            raise ImportError(
+                "To use the Weights and Biases Logger please install wandb."
+                "Run `pip install wandb` to install it."
+            )
+        
+        self._wandb = wandb
+
+        # Initialize a W&B run
+        if self._wandb.run is None:
+            self._wandb.init(
+                project=opt['wandb']['project'],
+                config=opt,
+                dir='./experiments'
+            )
+
+        self.config = self._wandb.config
+
+        if self.config['log_eval']:
+            self.eval_table = self._wandb.Table(columns=['fake_image', 
+                                                         'sr_image', 
+                                                         'hr_image',
+                                                         'psnr',
+                                                         'ssim'])
+
+    def log_metrics(self, metrics, commit=True): 
+        """
+        Log train/validation metrics onto W&B.
+
+        metrics: dictionary of metrics to be logged
+        """
+        self._wandb.log(metrics, commit=commit)
+
+    def log_image(self, key_name, image_array):
+        """
+        Log image array onto W&B.
+
+        key_name: name of the key 
+        image_array: numpy array of image.
+        """
+        self._wandb.log({key_name: self._wandb.Image(image_array)})
+
+    def log_checkpoint(self, current_epoch, current_step):
+        """
+        Log the model checkpoint as W&B artifacts
+
+        current_epoch: the current epoch 
+        current_step: the current batch step
+        """
+        model_artifact = self._wandb.Artifact(
+            self._wandb.run.id + "_model", type="model"
+        )
+
+        gen_path = os.path.join(
+            self.config.path['checkpoint'], 'I{}_E{}_gen.pth'.format(current_step, current_epoch))
+        opt_path = os.path.join(
+            self.config.path['checkpoint'], 'I{}_E{}_opt.pth'.format(current_step, current_epoch))
+
+        model_artifact.add_file(gen_path)
+        model_artifact.add_file(opt_path)
+        self._wandb.log_artifact(model_artifact, aliases=["latest"])
+
+    def log_eval_data(self, fake_img, sr_img, hr_img, psnr, ssim):
+        """
+        Add data row-wise to the initialized table.
+        """
+        self.eval_table.add_data(
+            self._wandb.Image(fake_img),
+            self._wandb.Image(sr_img),
+            self._wandb.Image(hr_img),
+            psnr,
+            ssim
+        )
+
+    def log_eval_table(self, commit=False):
+        """
+        Log the table
+        """
+        self._wandb.log({'eval_data': self.eval_table}, commit=commit)

--- a/sample.py
+++ b/sample.py
@@ -21,7 +21,6 @@ if __name__ == "__main__":
     parser.add_argument('-debug', '-d', action='store_true')
     parser.add_argument('-enable_wandb', action='store_true')
     parser.add_argument('-log_wandb_ckpt', action='store_true')
-    parser.add_argument('-log_eval', action='store_true')
 
     # parse configs
     args = parser.parse_args()
@@ -139,6 +138,7 @@ if __name__ == "__main__":
 
         result_path = '{}'.format(opt['path']['results'])
         os.makedirs(result_path, exist_ok=True)
+        sample_imgs = []
         for idx in range(sample_sum):
             idx += 1
             diffusion.sample(continous=True)
@@ -159,3 +159,8 @@ if __name__ == "__main__":
                     sample_img, '{}/{}_{}_sample_process.png'.format(result_path, current_step, idx))
                 Metrics.save_img(
                     Metrics.tensor2img(visuals['SAM'][-1]), '{}/{}_{}_sample.png'.format(result_path, current_step, idx))
+            
+            sample_imgs.append(Metrics.tensor2img(visuals['SAM'][-1]))
+
+        if wandb_logger:
+            wandb_logger.log_images('eval_images', sample_imgs)

--- a/sample.py
+++ b/sample.py
@@ -42,9 +42,6 @@ if __name__ == "__main__":
     # Initialize WandbLogger
     if opt['enable_wandb']:
         wandb_logger = WandbLogger(opt)
-        # wandb.define_metric('validation/val_step')
-        # wandb.define_metric('epoch')
-        # wandb.define_metric("validation/*", step_metric="val_step")
         val_step = 0
     else:
         wandb_logger = None

--- a/sr.py
+++ b/sr.py
@@ -5,9 +5,11 @@ import argparse
 import logging
 import core.logger as Logger
 import core.metrics as Metrics
+from core.wandb_logger import WandbLogger
 from tensorboardX import SummaryWriter
 import os
 import numpy as np
+import wandb
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -17,6 +19,9 @@ if __name__ == "__main__":
                         help='Run either train(training) or val(generation)', default='train')
     parser.add_argument('-gpu', '--gpu_ids', type=str, default=None)
     parser.add_argument('-debug', '-d', action='store_true')
+    parser.add_argument('-enable_wandb', action='store_true')
+    parser.add_argument('-log_wandb_ckpt', action='store_true')
+    parser.add_argument('-log_eval', action='store_true')
 
     # parse configs
     args = parser.parse_args()
@@ -34,6 +39,16 @@ if __name__ == "__main__":
     logger = logging.getLogger('base')
     logger.info(Logger.dict2str(opt))
     tb_logger = SummaryWriter(log_dir=opt['path']['tb_logger'])
+
+    # Initialize WandbLogger
+    if opt['enable_wandb']:
+        wandb_logger = WandbLogger(opt)
+        wandb.define_metric('validation/val_step')
+        wandb.define_metric('epoch')
+        wandb.define_metric("validation/*", step_metric="val_step")
+        val_step = 0
+    else:
+        wandb_logger = None
 
     # dataset
     for phase, dataset_opt in opt['datasets'].items():
@@ -81,6 +96,9 @@ if __name__ == "__main__":
                         tb_logger.add_scalar(k, v, current_step)
                     logger.info(message)
 
+                    if wandb_logger:
+                        wandb_logger.log_metrics(logs)
+
                 # validation
                 if current_step % opt['train']['val_freq'] == 0:
                     avg_psnr = 0.0
@@ -118,6 +136,12 @@ if __name__ == "__main__":
                         avg_psnr += Metrics.calculate_psnr(
                             sr_img, hr_img)
 
+                        if wandb_logger:
+                            wandb_logger.log_image(
+                                f'validation_{idx}', 
+                                np.concatenate((fake_img, sr_img, hr_img), axis=1)
+                            )
+
                     avg_psnr = avg_psnr / idx
                     diffusion.set_new_noise_schedule(
                         opt['model']['beta_schedule']['train'], schedule_phase='train')
@@ -129,9 +153,23 @@ if __name__ == "__main__":
                     # tensorboard logger
                     tb_logger.add_scalar('psnr', avg_psnr, current_step)
 
+                    if wandb_logger:
+                        wandb_logger.log_metrics({
+                            'validation/val_psnr': avg_psnr,
+                            'validation/val_step': val_step
+                        })
+                        val_step += 1
+
                 if current_step % opt['train']['save_checkpoint_freq'] == 0:
                     logger.info('Saving models and training states.')
                     diffusion.save_network(current_epoch, current_step)
+
+                    if wandb_logger and opt['log_wandb_ckpt']:
+                        wandb_logger.log_checkpoint(current_epoch, current_step)
+
+            if wandb_logger:
+                wandb_logger.log_metrics({'epoch': current_epoch-1})
+
         # save model
         logger.info('End of training.')
     else:
@@ -175,10 +213,15 @@ if __name__ == "__main__":
                 fake_img, '{}/{}_{}_inf.png'.format(result_path, current_step, idx))
 
             # generation
-            avg_psnr += Metrics.calculate_psnr(
-                Metrics.tensor2img(visuals['SR'][-1]), hr_img)
-            avg_ssim += Metrics.calculate_ssim(
-                Metrics.tensor2img(visuals['SR'][-1]), hr_img)
+            eval_psnr = Metrics.calculate_psnr(Metrics.tensor2img(visuals['SR'][-1]), hr_img)
+            eval_ssim = Metrics.calculate_ssim(Metrics.tensor2img(visuals['SR'][-1]), hr_img)
+
+            avg_psnr += eval_psnr
+            avg_ssim += eval_ssim
+
+            if wandb_logger and opt['log_eval']:
+                wandb_logger.log_eval_data(fake_img, Metrics.tensor2img(visuals['SR'][-1]), hr_img, eval_psnr, eval_ssim)
+
         avg_psnr = avg_psnr / idx
         avg_ssim = avg_ssim / idx
 
@@ -188,3 +231,11 @@ if __name__ == "__main__":
         logger_val = logging.getLogger('val')  # validation logger
         logger_val.info('<epoch:{:3d}, iter:{:8,d}> psnr: {:.4e}, ssim：{:.4e}'.format(
             current_epoch, current_step, avg_psnr, avg_ssim))
+
+        if wandb_logger:
+            if opt['log_eval']:
+                wandb_logger.log_eval_table()
+            wandb_logger.log_metrics({
+                'PSNR': float(avg_psnr),
+                'SSIM': float(avg_ssim)
+            })


### PR DESCRIPTION
This PR adds support for [Weights and Biases](https://wandb.ai/site) Metric, model checkpointing and evaluation logging. 

# Usage

I have added the functionality to `sr.py`, `sample.py` and `infer.py` files. To enable logging to W&B pass `-enable_wandb`.

## Super Resolution

* Train: `python sr.py -p train -c config/sr_sr3_16_128.json -enable_wandb -log_wandb_ckpt`
  Training and validation metrics, generated sr image and model checkpoint are logged as shown. 
  
  https://user-images.githubusercontent.com/31141479/149206194-eb5c3017-3859-4c32-bce5-633c29e35ac5.mov

* Evaluate: `python sr.py -p val -c config/sr_sr3_16_128.json -enable_wandb -log_eval`
  Below you can see the use of W&B Tables to log the result of evaluation.

  https://user-images.githubusercontent.com/31141479/149208390-755b2354-fec4-4a28-aa1f-82ed3deea202.mov

## Unconditional Image Generation

* Train: `python sample.py -p train -c config/sample_sr3_128.json -enable_wandb -log_wandb_ckpt`
  The resulting W&B run page will look similar to super-resolution one. 

* Evaluation: `python sample.py -p train -c config/sample_sr3_128.json -enable_wandb`
  Since the task is image generation, the generated images will be shown as a W&B image panel as shown. 
  
  <img width="1280" alt="image" src="https://user-images.githubusercontent.com/31141479/149209585-cf4b8764-cf97-4d82-be53-8c7925695a7d.png">

## Inference

To run inference `python infer.py -c config/sr_sr3_16_128.json -enable_wandb -log_infer`. This will give a table similar to evaluation but without `psnr` and `ssim` scores. 

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/31141479/149210110-7eb6ebd0-b6d6-4473-8129-db85b7cbadbe.png">

# Notes

* If `-enable_wandb` is not passed, the scripts will run without any issue (normally).
* The major code related to W&B is in the `core/wandb_logger.py` file.
* The screenshots and recordings are based on the results that I got by using `-debug` argument. However, I have tested the implementation on full training. 

I would love to know what you think of this and hope this will add value to your useful repository. 






